### PR TITLE
feat(server): add timeout configuration to CityGML packer

### DIFF
--- a/server/citygml/echo.go
+++ b/server/citygml/echo.go
@@ -18,6 +18,7 @@ type Config struct {
 	WorkerRegion       string `json:"workerRegion"`
 	WorkerProject      string `json:"workerProject"`
 	DataCatalogAPIURL  string `json:"dataCatalogApiUrl"`
+	PackerTimeout      uint   `json:"packerTimeout"`
 }
 
 var httpClient = &http.Client{

--- a/server/config.go
+++ b/server/config.go
@@ -91,6 +91,7 @@ type Config struct {
 	CityGML_CityGMLPackerImage         string   `pp:",omitempty"`
 	CityGML_WorkerRegion               string   `pp:",omitempty"`
 	CityGML_WorkerProject              string   `pp:",omitempty"`
+	CityGML_PackerTimeout              uint     `default:"30" pp:",omitempty"`
 	Flow_BaseURL                       string   `pp:",omitempty"`
 	Flow_Token                         string   `pp:",omitempty"`
 }
@@ -251,5 +252,6 @@ func (c *Config) CityGML() citygml.Config {
 		WorkerRegion:       workRegion,
 		WorkerProject:      workProject,
 		DataCatalogAPIURL:  c.LocalURL("/datacatalog"),
+		PackerTimeout:      c.CityGML_PackerTimeout,
 	}
 }

--- a/worker/citygmlpacker/config.go
+++ b/worker/citygmlpacker/config.go
@@ -1,7 +1,12 @@
 package citygmlpacker
 
+import (
+	"time"
+)
+
 type Config struct {
-	Dest   string
-	Domain string
-	URLs   []string
+	Dest    string
+	Domain  string
+	URLs    []string
+	Timeout time.Duration
 }

--- a/worker/main.go
+++ b/worker/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/eukarya-inc/reearth-plateauview/worker/citygmlpacker"
 	"github.com/eukarya-inc/reearth-plateauview/worker/extractmaxlod"
@@ -96,6 +97,7 @@ func cityGMLPacker(conf *Config) {
 	flag := flag.NewFlagSet("citygml-packer", flag.ExitOnError)
 	flag.StringVar(&config.Dest, "dest", "", "destination url (gs://...)")
 	flag.StringVar(&config.Domain, "domain", "", "allowed domain")
+	flag.DurationVar(&config.Timeout, "timeout", 30*time.Second, "timeout")
 	if err := flag.Parse(os.Args[2:]); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable timeout settings for CityGML packing operations, allowing users to specify custom timeout durations via a new command-line option.
- **Refactor**
  - Improved handling of packing requests with enhanced timeout and error tracking for better process control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->