### PR TITLE
fix(extension): correct the zfxy string format on spatial id layer

### DIFF
--- a/extension/src/prototypes/view/selection/LayerSpatialIdSection.tsx
+++ b/extension/src/prototypes/view/selection/LayerSpatialIdSection.tsx
@@ -95,8 +95,12 @@ export const LayerSpatialIdSection: FC<LayerSpatialIdSectionProps> = ({ layers }
     return [
       {
         id: "spaceIdZoomZFXY",
-        name: "ZFXY",
-        values: features.map(feature => feature.data.zfxyStr),
+        name: "z/f/x/y",
+        values: features.map(feature =>
+          feature.data.zfxyStr?.startsWith("/")
+            ? feature.data.zfxyStr.slice(1)
+            : feature.data.zfxyStr,
+        ),
       },
     ];
   }, [features]);

--- a/extension/src/prototypes/view/selection/SpatialIdObjectContent.tsx
+++ b/extension/src/prototypes/view/selection/SpatialIdObjectContent.tsx
@@ -110,11 +110,14 @@ export const SpatialIdObjectContent: FC<SpatialIdObjectContentProps> = ({ values
   const spaceIdZFXYProperties = useMemo(() => {
     const feature = features?.find(feature => parseIdentifier(values[0]).key === feature.id);
     if (!feature) return [];
+    const zfxy = feature.data.zfxyStr?.startsWith("/")
+      ? feature.data.zfxyStr.slice(1)
+      : feature.data.zfxyStr;
     return [
       {
         id: "spaceIdZFXY",
-        name: "ZFXY",
-        values: [feature.data.zfxyStr],
+        name: "z/f/x/y",
+        values: [zfxy],
       },
     ];
   }, [features, values]);


### PR DESCRIPTION
## Overview 

Correct the UI on spatial id selection panel:
- `ZFXY` -> `z/f/x/y`
- Remove the leading `/` on z/f/x/y string

| BEFORE    | AFTER |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/5168bf54-f82a-4cbf-89a0-048c0aa21d7a)  | ![image](https://github.com/user-attachments/assets/f0e0fc85-4111-4e5c-bcb6-031fcf8322bb)  |
| ![image](https://github.com/user-attachments/assets/6bb480be-e6c4-4a5a-b7a4-2274de863090) | ![image](https://github.com/user-attachments/assets/b0fef0cc-3196-4110-92f1-318a2d946493) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The spatial identifier display now uses a refined label ("z/f/x/y") for improved clarity.
	- Value formatting has been enhanced to automatically remove any unwanted leading characters, ensuring a cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->