### PR TITLE
fix: use KML style

### DIFF
--- a/extension/src/shared/layerContainers/myData.tsx
+++ b/extension/src/shared/layerContainers/myData.tsx
@@ -96,14 +96,17 @@ export const MyDataLayerContainer: FC<MyDataContainerProps> = ({
   const theme = useTheme();
 
   const defaultAppearance = useMemo(
-    () => ({
-      ...DEFAULT_MYDATA_APPEARANCES,
-      polyline: {
-        ...DEFAULT_MYDATA_APPEARANCES.polyline,
-        // KML with clampToGround causes an error, so disable it: https://github.com/CesiumGS/cesium/issues/9555
-        clampToGround: format === "kml" ? false : true,
-      },
-    }),
+    () =>
+      format === "kml"
+        ? {
+            polyline: {
+              // KML with clampToGround causes an error, so force it to be disabled: https://github.com/CesiumGS/cesium/issues/9555
+              clampToGround: false,
+            },
+          }
+        : {
+            ...DEFAULT_MYDATA_APPEARANCES,
+          },
     [format],
   );
 


### PR DESCRIPTION
I fixed an issue that KML style isn't applied due to PLATEAU extension provide a default style. I fixed to avoid providing the default style for KML.

![Screenshot 2025-05-22 at 17 44 29](https://github.com/user-attachments/assets/802c79c2-b303-4980-9bef-fd8ac6596f5b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved compatibility for KML format by adjusting polyline appearance settings, resolving issues with certain visualizations. Other formats remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->