### PR TITLE
fix: transparent color should work in conditional color expression

### DIFF
--- a/extension/src/shared/helpers/expression.ts
+++ b/extension/src/shared/helpers/expression.ts
@@ -6,7 +6,7 @@ export const string = (v: string) => {
 };
 
 export const color = (v: string, alpha: number) => {
-  return `color("${v}", ${alpha})`;
+  return v === "transparent" ? `"${v}"` : `color("${v}", ${alpha})`;
 };
 
 export const number = (v: number) => {


### PR DESCRIPTION
`Color` component is working well, but the specified color wasn't applied even when you specify `transparent` as color in `Color condition` component. I fixed this issue.

|Before|After|
|:--:|:--:|
|![image](https://github.com/user-attachments/assets/be047749-cd9a-4318-bdc7-7b571c18125d)|![Screenshot 2025-05-23 at 17 57 22](https://github.com/user-attachments/assets/648c8d97-8a58-477b-9436-aa84933807a7)|



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved color handling to correctly display "transparent" without unnecessary formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->