### PR TITLE
fix(extension): use thier own style for CZML in mydata

### DIFF
--- a/extension/src/shared/layerContainers/myData.tsx
+++ b/extension/src/shared/layerContainers/myData.tsx
@@ -26,6 +26,9 @@ type MyDataContainerProps = Omit<GeneralProps, "appearances" | "appendData"> & {
   cameraAtom?: PrimitiveAtom<CameraPosition | undefined>;
 };
 
+// These datasets should use their own styles.
+const DATASETS_USING_OWN_STYLE = ["kml", "czml"];
+
 export const MyDataLayerContainer: FC<MyDataContainerProps> = ({
   id,
   onLoad,
@@ -97,7 +100,7 @@ export const MyDataLayerContainer: FC<MyDataContainerProps> = ({
 
   const defaultAppearance = useMemo(
     () =>
-      format === "kml"
+      DATASETS_USING_OWN_STYLE.includes(format)
         ? {
             polyline: {
               // KML with clampToGround causes an error, so force it to be disabled: https://github.com/CesiumGS/cesium/issues/9555


### PR DESCRIPTION
I fixed to use the default style for CZML in MyData in same reason with https://github.com/eukarya-inc/PLATEAU-VIEW/pull/460.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved appearance handling for datasets, ensuring both "kml" and "czml" formats use their own styles for polylines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->