### PR TITLE
fix(extension): enable includeParents flag in dataset type list

### DIFF
--- a/extension/src/prototypes/view/ui-containers/DatasetTypeList.tsx
+++ b/extension/src/prototypes/view/ui-containers/DatasetTypeList.tsx
@@ -91,6 +91,7 @@ const PrefectureItem: FC<{
   const query = useAreas({
     parentCode: prefecture.code,
     datasetTypes: [datasetType],
+    includeParents: true,
   });
 
   // Handle the datasets belongs to this perfecture and type but no municipality


### PR DESCRIPTION
`宮城県(Miyagi-prefecture)` was disabled even if data is exist. The cause was `includeParents` flag isn't enabled when the area query is sent. I fixed to enable `includeParents` flag, then it is working well.

|Before|After|
|:--:|:--:|
|<img width="1296" height="881" alt="Screenshot 2025-07-11 at 9 16 02" src="https://github.com/user-attachments/assets/3bb64bc0-5391-4ceb-b364-1d0f1ad0ce7d" />|<img width="1296" height="881" alt="Screenshot 2025-07-11 at 9 14 38" src="https://github.com/user-attachments/assets/42a95c70-65fd-42be-9fca-1efdb43876c2" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Area lists now include parent areas when viewing datasets by prefecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->