### PR TITLE
fix: make gcs bucket name unique

### DIFF
--- a/terraform/gcp/google_storage_bucket.tf
+++ b/terraform/gcp/google_storage_bucket.tf
@@ -9,7 +9,7 @@ resource "google_storage_bucket" "cerbos_policy" {
   project = data.google_project.project.project_id
 
   location      = var.gcp_region
-  name          = "cerbos-policy"
+  name          = "${var.prefix}-cerbos-policy"
   storage_class = "STANDARD"
 }
 
@@ -54,13 +54,13 @@ resource "google_storage_bucket" "terraform" {
 resource "google_storage_bucket" "plateau_flow_bucket" {
   project = data.google_project.project.project_id
 
-  name     = "plateau-flow-oss-bucket"
+  name     = "${var.prefix}-plateau-flow-oss-bucket"
   location = "asia-northeast1"
 }
 
 resource "google_storage_bucket" "plateau_flow_websocket_bucket" {
   project = data.google_project.project.project_id
 
-  name     = "plateau-flow-websocket-bucket"
+  name     = "${var.prefix}-plateau-flow-websocket-bucket"
   location = "asia-northeast1"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage bucket names to use a dynamic prefix, enabling more flexible and consistent naming across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->