### PR TITLE
chore: add HTTPS redirect to user-facing load balancers

### DIFF
--- a/terraform/gcp/google_compute_global_forwarding_rule.tf
+++ b/terraform/gcp/google_compute_global_forwarding_rule.tf
@@ -29,6 +29,18 @@ resource "google_compute_global_forwarding_rule" "plateau_cms" {
   target                = google_compute_target_https_proxy.plateau_cms.self_link
 }
 
+resource "google_compute_global_forwarding_rule" "plateau_cms_http" {
+  project = data.google_project.project.project_id
+
+  name                  = "plateau-cms-http"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  ip_address            = google_compute_global_address.cms.id
+  ip_protocol           = "TCP"
+  port_range            = "80"
+  target                = google_compute_target_http_proxy.plateau_cms.id
+}
+
+
 resource "google_compute_global_forwarding_rule" "editor" {
   project = data.google_project.project.project_id
 
@@ -38,6 +50,17 @@ resource "google_compute_global_forwarding_rule" "editor" {
   ip_protocol           = "TCP"
   port_range            = "443"
   target                = google_compute_target_https_proxy.editor.id
+}
+
+resource "google_compute_global_forwarding_rule" "editor_http" {
+  project = data.google_project.project.project_id
+
+  name                  = "editor-http"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  ip_address            = google_compute_global_address.editor.id
+  ip_protocol           = "TCP"
+  port_range            = "80"
+  target                = google_compute_target_http_proxy.editor.id
 }
 
 resource "google_compute_global_forwarding_rule" "plateau_api" {
@@ -60,4 +83,15 @@ resource "google_compute_global_forwarding_rule" "plateau_flow" {
   ip_protocol           = "TCP"
   port_range            = "443"
   target                = google_compute_target_https_proxy.plateau_flow.id
+}
+
+resource "google_compute_global_forwarding_rule" "plateau_flow_http" {
+  project = data.google_project.project.project_id
+
+  name                  = "plateau-flow-http"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  ip_address            = google_compute_global_address.plateau_flow.id
+  ip_protocol           = "TCP"
+  port_range            = "80"
+  target                = google_compute_target_http_proxy.plateau_flow.id
 }

--- a/terraform/gcp/google_compute_target_http_proxy.tf
+++ b/terraform/gcp/google_compute_target_http_proxy.tf
@@ -1,0 +1,17 @@
+resource "google_compute_target_http_proxy" "editor" {
+  project = data.google_project.project.project_id
+  name    = "editor"
+  url_map = google_compute_url_map.editor_http_redirect.id
+}
+
+resource "google_compute_target_http_proxy" "plateau_cms" {
+  project = data.google_project.project.project_id
+  name    = "plateau-cms"
+  url_map = google_compute_url_map.plateau_cms_http_redirect.id
+}
+
+resource "google_compute_target_http_proxy" "plateau_flow" {
+  project = data.google_project.project.project_id
+  name    = "plateau-flow"
+  url_map = google_compute_url_map.plateau_flow_http_redirect.id
+}

--- a/terraform/gcp/google_compute_url_map.tf
+++ b/terraform/gcp/google_compute_url_map.tf
@@ -36,6 +36,18 @@ resource "google_compute_url_map" "accounts" {
   }
 }
 
+resource "google_compute_url_map" "editor_http_redirect" {
+  project = data.google_project.project.project_id
+
+  name        = "editor-http-redirect"
+  description = "Url map for Editor HTTP Redirect"
+
+  default_url_redirect {
+    https_redirect = true
+    strip_query    = false
+  }
+}
+
 resource "google_compute_url_map" "plateau_cms" {
   project = data.google_project.project.project_id
 
@@ -84,6 +96,19 @@ resource "google_compute_url_map" "plateau_cms" {
     default_service = google_compute_backend_service.cms_worker.id
   }
 }
+
+resource "google_compute_url_map" "plateau_cms_http_redirect" {
+  project = data.google_project.project.project_id
+
+  name        = "plateau-cms-http-redirect"
+  description = "Url map for Plateau CMS HTTP Redirect"
+
+  default_url_redirect {
+    https_redirect = true
+    strip_query    = false
+  }
+}
+
 
 resource "google_compute_url_map" "editor" {
   project = data.google_project.project.project_id
@@ -278,5 +303,17 @@ resource "google_compute_url_map" "plateau_flow" {
   path_matcher {
     name            = "websocket"
     default_service = google_compute_backend_service.plateau_flow_websocket.id
+  }
+}
+
+resource "google_compute_url_map" "plateau_flow_http_redirect" {
+  project = data.google_project.project.project_id
+
+  name        = "plateau-flow-http-redirect"
+  description = "Url map for Plateau Flow HTTP Redirect"
+
+  default_url_redirect {
+    https_redirect = true
+    strip_query    = false
   }
 }


### PR DESCRIPTION
## Why

For security improvements, `http` shouldn't be used for these environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for HTTP traffic (port 80) with new global forwarding rules for "plateau_cms," "editor," and "plateau_flow" services.
  * Implemented automatic HTTP-to-HTTPS redirection for these services, ensuring secure access by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->