### PR TITLE
fix: allow loading MVT without metadata

### DIFF
--- a/extension/src/shared/reearth/layers/mvt.ts
+++ b/extension/src/shared/reearth/layers/mvt.ts
@@ -143,7 +143,6 @@ export const MVTLayer: FC<MVTProps> = ({
     visible,
     appearances: mergedAppearances,
     onLoad: handleOnLoad,
-    loading: !meta,
   });
 
   return null;


### PR DESCRIPTION
I fixed to allow loading MVT without metadata.json, since the selected data doesn't include it.
<img width="1918" height="880" alt="Screenshot 2025-10-07 at 11 44 41" src="https://github.com/user-attachments/assets/7f7c1665-ddb5-4a17-84b4-690599eba3b2" />
